### PR TITLE
Fix TypeScript optional Props

### DIFF
--- a/src/FontPicker.tsx
+++ b/src/FontPicker.tsx
@@ -20,14 +20,14 @@ interface Props {
 	onChange: (font: Font) => void;
 
 	// Optional props
-	pickerId: string;
-	families: string[];
-	categories: Category[];
-	scripts: Script[];
-	variants: Variant[];
-	filter: (font: Font) => boolean;
-	limit: number;
-	sort: SortOption;
+	pickerId?: string;
+	families?: string[];
+	categories?: Category[];
+	scripts?: Script[];
+	variants?: Variant[];
+	filter?: (font: Font) => boolean;
+	limit?: number;
+	sort?: SortOption;
 }
 
 interface State {


### PR DESCRIPTION
Fix for correct optional properties syntax. Otherwise it will require all the props to be passed in the component.